### PR TITLE
Create 2022-01-06.md

### DIFF
--- a/2022/2022-01-06.md
+++ b/2022/2022-01-06.md
@@ -1,0 +1,29 @@
+# Napari developer meetings
+
+## 2022-1-6
+[Justine] Bundle app
+* Windows certificate and signing
+
+[Nathan] plugin wg update
+* hackathon
+* future directions
+    * mouse functions?
+
+[Andy] architecture wg update
+
+[Andy] file size checker action
+
+[Jordao] Interactive Tracks PR [#3896](https://github.com/napari/napari/pull/3896);
+
+### Last week's action items
+
+### This week Agenda
+
+## New action items
+
+------
+
+At the end of the meeting:
+- Copy the contents of this document to a new file in https://github.com/napari/meeting-notes
+- Clear out the Agenda from last meeting
+


### PR DESCRIPTION
Meeting notes from the napari community meeting 6th January 2022 (USA - Australia timezones)

(Found these meeting notes still in the hackMD when we went to add a new item to the agenda for the next meeting)